### PR TITLE
RenderTarget File I/O

### DIFF
--- a/include/vistrace/IRenderTarget.h
+++ b/include/vistrace/IRenderTarget.h
@@ -62,7 +62,7 @@ namespace VisTrace
 		virtual Pixel GetPixel(uint16_t x, uint16_t y, uint8_t mip = 0) const = 0;
 		virtual void SetPixel(uint16_t x, uint16_t y, const Pixel& pixel, uint8_t mip = 0) = 0;
 
-		virtual bool Load(const char* filepath, bool generateMips = true, bool scaleToRT = false) = 0;
+		virtual bool Load(const char* filepath, bool generateMips = false) = 0;
 		virtual bool Save(const char* filename, uint8_t mip = 0) = 0;
 
 		virtual void GenerateMIPs() = 0;

--- a/include/vistrace/IRenderTarget.h
+++ b/include/vistrace/IRenderTarget.h
@@ -62,6 +62,9 @@ namespace VisTrace
 		virtual Pixel GetPixel(uint16_t x, uint16_t y, uint8_t mip = 0) const = 0;
 		virtual void SetPixel(uint16_t x, uint16_t y, const Pixel& pixel, uint8_t mip = 0) = 0;
 
+		virtual bool Load(const char* filepath, bool generateMips = true, bool scaleToRT = false) = 0;
+		virtual bool Save(const char* filename, uint8_t mip = 0) = 0;
+
 		virtual void GenerateMIPs() = 0;
 	};
 }

--- a/source/Utils.cpp
+++ b/source/Utils.cpp
@@ -85,6 +85,14 @@ std::string GetMaterialString(ILuaBase* LUA, const std::string& key)
 	return val;
 }
 
+uint8_t MipsFromDimensions(uint16_t width, uint16_t height) {
+	int widthMips = ceilf(log2(static_cast<float>(width)));
+	int heightMips = ceilf(log2(static_cast<float>(height)));
+
+	float floatMips = fmaxf(widthMips, heightMips) + 1.f;
+	return static_cast<uint8_t>(floatMips);
+}
+
 bool ReadTexture(const std::string& path, VTFTexture** ppTextureOut)
 {
 	std::string texturePath = "materials/" + path + ".vtf";

--- a/source/Utils.h
+++ b/source/Utils.h
@@ -5,6 +5,7 @@
 #include "VTFParser.h"
 
 #include <string>
+#include <cstdint>
 #include <vector>
 
 // Print a string to console using Lua
@@ -36,6 +37,14 @@ Vector MakeVector(const float x, const float y, const float z);
 /// <param name="key">String key</param>
 /// <returns>Value at the key or an empty string</returns>
 std::string GetMaterialString(GarrysMod::Lua::ILuaBase* LUA, const std::string& key);
+
+/// <summary>
+/// Calculates the minimum amount of mip levels to generate from the dimensions given.
+/// </summary>
+/// <param name="width">Width of image</param>
+/// <param name="height">Height of image</param>
+/// <returns>Mip level</returns>
+uint8_t MipsFromDimensions(uint16_t width, uint16_t height);
 
 /// <summary>
 /// VMT flags

--- a/source/VisTrace.cpp
+++ b/source/VisTrace.cpp
@@ -218,6 +218,48 @@ LUA_FUNCTION(RT_SetPixel)
 	return 0;
 }
 
+LUA_FUNCTION(RT_Load)
+{
+	LUA->CheckType(1, RenderTarget::id);
+	LUA->CheckType(2, Type::String);
+	// 3 and 4 are generateMips and scaleToRT respectively, they are both optional, but generateMips is true by default and cannot use the shorthand method for optional booleans.
+
+	const char* filepath = LUA->GetString(2);
+	bool generateMips = true;
+	if (LUA->IsType(3, Type::Bool)) {
+		generateMips = LUA->GetBool(3);
+	}
+
+	bool scaleToRT = LUA->GetBool(4);
+
+	RenderTarget* pRt = *LUA->GetUserType<RenderTarget*>(1, RenderTarget::id);
+	bool loaded = pRt->Load(filepath, generateMips, scaleToRT);
+
+	if (!loaded) {
+		LUA->ThrowError("Failed to load the image into the render target!");
+	}
+
+	return 0;
+}
+
+LUA_FUNCTION(RT_Save)
+{
+	LUA->CheckType(1, RenderTarget::id);
+	LUA->CheckType(2, Type::String);
+	
+	RenderTarget* pRt = *LUA->GetUserType<RenderTarget*>(1, RenderTarget::id);
+	const char* filepath = LUA->GetString(2);
+	uint8_t mip = LUA->GetNumber(3); // Returns 0 if not specified
+
+	bool wrote = pRt->Save(filepath, mip);
+
+	if (!wrote) {
+		LUA->ThrowError("Failed to write the render target into the image!");
+	}
+
+	return 0;
+}
+
 LUA_FUNCTION(RT_GenerateMIPs)
 {
 	LUA->CheckType(1, RenderTarget::id);
@@ -1010,6 +1052,11 @@ GMOD_MODULE_OPEN()
 		LUA->SetField(-2, "GetPixel");
 		LUA->PushCFunction(RT_SetPixel);
 		LUA->SetField(-2, "SetPixel");
+
+		LUA->PushCFunction(RT_Load);
+		LUA->SetField(-2, "Load");
+		LUA->PushCFunction(RT_Save);
+		LUA->SetField(-2, "Save");
 
 		LUA->PushCFunction(RT_GenerateMIPs);
 		LUA->SetField(-2, "GenerateMIPs");

--- a/source/objects/RenderTarget.cpp
+++ b/source/objects/RenderTarget.cpp
@@ -1,10 +1,18 @@
 #include "RenderTarget.h"
+#include "stb_image.h"
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"
+#define STB_IMAGE_RESIZE_IMPLEMENTATION
+#include "stb_image_resize.h"
 
+#include <filesystem>
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
+#include <unordered_map>
 
 using namespace VisTrace;
+namespace fs = std::filesystem;
 
 int RenderTarget::id{ -1 };
 
@@ -207,6 +215,174 @@ Pixel RenderTarget::SampleBilinear(float u, float v, uint8_t mip) const
 		(corners[0][0].a * uFractInv + corners[1][0].a * uFract) * vFractInv +
 		(corners[0][1].a * uFractInv + corners[1][1].a * uFract) * vFract,
 	};
+}
+
+bool RenderTarget::Load(const char* filepath, bool generateMips, bool scaleToRT)
+{
+	if (!IsValid()) return false;
+
+	int imageWidth = 0;
+	int imageHeight = 0;
+	int channels = CHANNELS[static_cast<uint8_t>(GetFormat())];
+	size_t stride = STRIDES[static_cast<uint8_t>(GetFormat())];
+	
+	uint8_t* rtData = GetRawData();
+	const bool isFloat = stride == sizeof(float);
+
+	if (isFloat) {
+		float* imageData = stbi_loadf(filepath, &imageWidth, &imageHeight, nullptr, channels);
+		if (imageData) {
+			// Check if we require a resize to the RT's dimensions.
+			if (scaleToRT) {
+				uint16_t width = GetWidth();
+				uint16_t height = GetHeight();
+
+				// We can do a cool trick and skip any mediums and directly have the resized image be written into the RT's image buffer.
+				int resized = stbir_resize_float(imageData, imageWidth, imageHeight, channels * stride * imageWidth, reinterpret_cast<float*>(rtData), width, height, channels * stride * width, channels);
+				if (!resized) {
+					stbi_image_free(imageData);
+					return false;
+				}
+
+				stbi_image_free(imageData);
+			}
+			else {
+				// Resize the RT to fit the image.
+				bool resized = Resize(imageWidth, imageHeight);
+				if (!resized) {
+					stbi_image_free(imageData);
+					return false;
+				}
+
+				memcpy(reinterpret_cast<void*>(GetRawData()), reinterpret_cast<void*>(imageData), stride * imageWidth * imageHeight * channels);
+				stbi_image_free(imageData);
+			}
+		}
+		else {
+			return false;
+		}
+	}
+	else {
+		stbi_uc* imageData = stbi_load(filepath, &imageWidth, &imageHeight, nullptr, channels);
+		if (imageData) {
+			// Check if we require a resize to the RT's dimensions.
+			if (scaleToRT) {
+				uint16_t width = GetWidth();
+				uint16_t height = GetHeight();
+
+				// We can do a cool trick and skip any mediums and directly have the resized image be written into the RT's image buffer.
+				int resized = stbir_resize_uint8(imageData, imageWidth, imageHeight, channels * stride * imageWidth, reinterpret_cast<uint8_t*>(rtData), width, height, channels * stride * width, channels);
+				if (!resized) {
+					stbi_image_free(imageData);
+					return false;
+				}
+
+				stbi_image_free(imageData);
+			}
+			else {
+				// Resize the RT to fit the image.
+				bool resized = Resize(imageWidth, imageHeight);
+				if (!resized) {
+					stbi_image_free(imageData);
+					return false;
+				}
+
+				memcpy(reinterpret_cast<void*>(GetRawData()), reinterpret_cast<void*>(imageData), stride * imageWidth * imageHeight * channels);
+				stbi_image_free(imageData);
+			}
+		}
+		else {
+			return false;
+		}
+	}
+
+	// MIP generation works on any type of buffer.
+	if (generateMips) {
+		GenerateMIPs();
+	}
+
+	return true;
+}
+
+bool RenderTarget::Save(const char* filename, uint8_t mip)
+{
+	int channels = CHANNELS[static_cast<uint8_t>(GetFormat())];
+	if (GetMIPs() <= mip) {
+		return false;
+	}
+
+	fs::path filepath(filename);
+	filepath = filepath.make_preferred();
+
+	fs::path workingDir = fs::current_path();
+
+	workingDir += "/garrysmod/data";
+	workingDir = workingDir.make_preferred();
+	workingDir = workingDir.lexically_normal();
+
+	const bool isFloat = mChannelSize == sizeof(float);
+	std::string extension = isFloat ? "hdr" : "png";
+
+	bool createSubdirectories = filepath.has_parent_path(); // Returns true if the filename is like "renders/output.png"
+
+	if (filepath.has_extension()) {
+		fs::path fileExt = filepath.extension();
+		std::string ext = fileExt.string();
+		ext = ext.substr(1); // Extension returns the period along with the actual extension.
+
+		if (ext == "hdr" || ext == "png" || ext == "jpg" || ext == "bmp") {
+			extension = ext; // Change the default to the requested one
+		}
+		else {
+			// Append the default extension.
+			// Great for things like: "frame.001"
+			filepath += "." + extension;
+		}
+	}
+
+	fs::path finalPath = workingDir / filepath;
+	finalPath = finalPath.lexically_normal(); // Absolute.
+
+	// We can assure that the user did not go out of bounds by checking that the root is equal to the working directory.
+	std::string finalPathString = finalPath.string();
+	std::string workingDirString = workingDir.string();
+
+	std::string root = finalPathString.substr(0, workingDirString.length());
+	if (root != workingDirString) {
+		return false; // User exited the data directory.
+	}
+	
+	if (createSubdirectories) {
+		fs::create_directories(finalPath.parent_path());
+	}
+
+	const char* rawFilepath = finalPath.string().c_str();
+	
+	if (extension == "hdr") {
+		if (!stbi_write_hdr(rawFilepath, GetWidth(), GetHeight(), channels, reinterpret_cast<const float*>(GetRawData(mip)))) {
+			return false;
+		}
+	}
+	else if (extension == "png") {
+		if (!stbi_write_png(rawFilepath, GetWidth(), GetHeight(), channels, reinterpret_cast<const void*>(GetRawData(mip)), mPixelSize * GetWidth())) {
+			return false;
+		}
+	}
+	else if (extension == "jpg") {
+		if (!stbi_write_jpg(rawFilepath, GetWidth(), GetHeight(), channels, reinterpret_cast<const void*>(GetRawData(mip)), 50)) {
+			return false;
+		}
+	}
+	else if (extension == "bmp") {
+		if (!stbi_write_bmp(rawFilepath, GetWidth(), GetHeight(), channels, reinterpret_cast<const void*>(GetRawData(mip)))) {
+			return false;
+		}
+	}
+	else {
+		return false;
+	}
+
+	return true;
 }
 
 void RenderTarget::GenerateMIPs()

--- a/source/objects/RenderTarget.h
+++ b/source/objects/RenderTarget.h
@@ -57,5 +57,8 @@ public:
 	VisTrace::Pixel GetPixel(uint16_t x, uint16_t y, uint8_t mip = 0) const;
 	void SetPixel(uint16_t x, uint16_t y, const VisTrace::Pixel& pixel, uint8_t mip = 0);
 
+	bool Load(const char* filepath, bool generateMips = true, bool scaleToRT = false);
+	bool Save(const char* filename, uint8_t mip = 0);
+
 	void GenerateMIPs();
 };

--- a/source/objects/RenderTarget.h
+++ b/source/objects/RenderTarget.h
@@ -57,7 +57,7 @@ public:
 	VisTrace::Pixel GetPixel(uint16_t x, uint16_t y, uint8_t mip = 0) const;
 	void SetPixel(uint16_t x, uint16_t y, const VisTrace::Pixel& pixel, uint8_t mip = 0);
 
-	bool Load(const char* filepath, bool generateMips = true, bool scaleToRT = false);
+	bool Load(const char* filepath, bool generateMips = false);
 	bool Save(const char* filename, uint8_t mip = 0);
 
 	void GenerateMIPs();


### PR DESCRIPTION
Fixes #42.

**PR Type (tick all that are applicable)**
- [ ] Bug Fix
- [ ] New Feature (doesn't break Module <-> Lua compatibility)
- [x] New Feature (breaks Module <-> Lua compatibility)
- [x] Documentation Update Required

**Tested Targets (only applicable for changes to the binary module, delete otherwise)**
- [x] windows-x64-release
- [ ] windows-x86-release (currently not possible)

**Checklist**
- [x] I have read and understand the contributing guidelines
- [x] I have tested all aspects of this PR (not required)
- [ ] I have added the watermark on the branding branch with my desired name to any content attached where applicable (only applies to showcase submissions)

**Description**
When merged, this will add "Load" and "Save" to rendertargets allowing them to be saved onto the disk and have their content loaded from the disk.