### PR TITLE
BSDFMaterial properties can now be accessed from Lua

### DIFF
--- a/source/VisTrace.cpp
+++ b/source/VisTrace.cpp
@@ -738,20 +738,9 @@ LUA_FUNCTION(Material_Colour)
 	LUA->CheckType(1, BSDFMaterial::id);
 
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
-	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
-		Vector v;
-		v.x = pMat->dielectricInput.x;
-		v.y = pMat->dielectricInput.y;
-		v.z = pMat->dielectricInput.z;
-
-		Vector v2;
-		v2.x = pMat->conductorInput.x;
-		v2.y = pMat->conductorInput.y;
-		v2.z = pMat->conductorInput.z;
-
-		LUA->PushVector(v);
-		LUA->PushVector(v2);
-
+	if (LUA->Top() == 1) {
+		LUA->PushVector(MakeVector(pMat->dielectricInput.x, pMat->dielectricInput.y, pMat->dielectricInput.z));
+		LUA->PushVector(MakeVector(pMat->conductorInput.x, pMat->conductorInput.y, pMat->conductorInput.z));
 		return 2;
 	}
 
@@ -767,13 +756,8 @@ LUA_FUNCTION(Material_DielectricColour)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
-	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
-		Vector v;
-		v.x = pMat->dielectricInput.x;
-		v.y = pMat->dielectricInput.y;
-		v.z = pMat->dielectricInput.z;
-		LUA->PushVector(v);
-
+	if (LUA->Top() == 1) {
+		LUA->PushVector(MakeVector(pMat->dielectricInput.x, pMat->dielectricInput.y, pMat->dielectricInput.z));
 		return 1;
 	}
 
@@ -787,13 +771,8 @@ LUA_FUNCTION(Material_ConductorColour)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
-	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
-		Vector v;
-		v.x = pMat->conductorInput.x;
-		v.y = pMat->conductorInput.y;
-		v.z = pMat->conductorInput.z;
-		LUA->PushVector(v);
-
+	if (LUA->Top() == 1) {
+		LUA->PushVector(MakeVector(pMat->conductorInput.x, pMat->conductorInput.y, pMat->conductorInput.z));
 		return 1;
 	}
 
@@ -807,13 +786,8 @@ LUA_FUNCTION(Material_EdgeTint)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
-	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
-		Vector v;
-		v.x = pMat->edgetint.x;
-		v.y = pMat->edgetint.y;
-		v.z = pMat->edgetint.z;
-		LUA->PushVector(v);
-
+	if (LUA->Top() == 1) {
+		LUA->PushVector(MakeVector(pMat->edgetint.x, pMat->edgetint.y, pMat->edgetint.z));
 		return 1;
 	}
 
@@ -827,7 +801,7 @@ LUA_FUNCTION(Material_EdgeTintFalloff)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
-	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+	if (LUA->Top() == 1) {
 		LUA->PushNumber(pMat->falloff);
 		return 1;
 	}
@@ -841,7 +815,7 @@ LUA_FUNCTION(Material_Metalness)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
-	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+	if (LUA->Top() == 1) {
 		LUA->PushNumber(pMat->metallic);
 		return 1;
 	}
@@ -855,8 +829,8 @@ LUA_FUNCTION(Material_Roughness)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
-	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
-		LUA->PushNumber(pMat->roughness);
+	if (LUA->Top() == 1) {
+		LUA->PushNumber(pMat->linearRoughness);
 		return 1;
 	}
 
@@ -871,7 +845,7 @@ LUA_FUNCTION(Material_Anisotropy)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
-	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+	if (LUA->Top() == 1) {
 		LUA->PushNumber(pMat->anisotropy);
 		return 1;
 	}
@@ -888,7 +862,7 @@ LUA_FUNCTION(Material_AnisotropicRotation)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
-	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+	if (LUA->Top() == 1) {
 		LUA->PushNumber(pMat->anisotropicRotation);
 		return 1;
 	}
@@ -903,7 +877,7 @@ LUA_FUNCTION(Material_IoR)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
-	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+	if (LUA->Top() == 1) {
 		LUA->PushNumber(pMat->ior);
 		return 1;
 	}
@@ -917,7 +891,7 @@ LUA_FUNCTION(Material_DiffuseTransmission)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
-	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+	if (LUA->Top() == 1) {
 		LUA->PushNumber(pMat->diffuseTransmission);
 		return 1;
 	}
@@ -930,7 +904,7 @@ LUA_FUNCTION(Material_SpecularTransmission)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
-	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+	if (LUA->Top() == 1) {
 		LUA->PushNumber(pMat->specularTransmission);
 		return 1;
 	}
@@ -944,7 +918,7 @@ LUA_FUNCTION(Material_Thin)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
-	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+	if (LUA->Top() == 1) {
 		LUA->PushBool(pMat->thin);
 		return 1;
 	}
@@ -958,7 +932,7 @@ LUA_FUNCTION(Material_ActiveLobes)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
-	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+	if (LUA->Top() == 1) {
 		LUA->PushNumber(static_cast<int>(pMat->activeLobes));
 		return 1;
 	}

--- a/source/VisTrace.cpp
+++ b/source/VisTrace.cpp
@@ -933,7 +933,7 @@ LUA_FUNCTION(Material_ActiveLobes)
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
 	if (LUA->Top() == 1) {
-		LUA->PushNumber(static_cast<int>(pMat->activeLobes));
+		LUA->PushNumber(static_cast<double>(pMat->activeLobes));
 		return 1;
 	}
 

--- a/source/VisTrace.cpp
+++ b/source/VisTrace.cpp
@@ -736,9 +736,26 @@ LUA_FUNCTION(vistrace_CreateMaterial)
 LUA_FUNCTION(Material_Colour)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
-	LUA->CheckType(2, Type::Vector);
 
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
+	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+		Vector v;
+		v.x = pMat->dielectricInput.x;
+		v.y = pMat->dielectricInput.y;
+		v.z = pMat->dielectricInput.z;
+
+		Vector v2;
+		v2.x = pMat->conductorInput.x;
+		v2.y = pMat->conductorInput.y;
+		v2.z = pMat->conductorInput.z;
+
+		LUA->PushVector(v);
+		LUA->PushVector(v2);
+
+		return 2;
+	}
+
+	LUA->CheckType(2, Type::Vector);
 	Vector v = LUA->GetVector(2);
 	pMat->dielectricInput = glm::clamp(glm::vec3(v.x, v.y, v.z), 0.f, 1.f);
 	pMat->conductorInput = pMat->conductor = pMat->dielectric = pMat->dielectricInput;
@@ -749,9 +766,18 @@ LUA_FUNCTION(Material_Colour)
 LUA_FUNCTION(Material_DielectricColour)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
-	LUA->CheckType(2, Type::Vector);
-
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
+	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+		Vector v;
+		v.x = pMat->dielectricInput.x;
+		v.y = pMat->dielectricInput.y;
+		v.z = pMat->dielectricInput.z;
+		LUA->PushVector(v);
+
+		return 1;
+	}
+
+	LUA->CheckType(2, Type::Vector);
 	Vector v = LUA->GetVector(2);
 	pMat->dielectricInput = pMat->dielectric = glm::clamp(glm::vec3(v.x, v.y, v.z), 0.f, 1.f);
 	return 0;
@@ -760,9 +786,18 @@ LUA_FUNCTION(Material_DielectricColour)
 LUA_FUNCTION(Material_ConductorColour)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
-	LUA->CheckType(2, Type::Vector);
-
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
+	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+		Vector v;
+		v.x = pMat->conductorInput.x;
+		v.y = pMat->conductorInput.y;
+		v.z = pMat->conductorInput.z;
+		LUA->PushVector(v);
+
+		return 1;
+	}
+
+	LUA->CheckType(2, Type::Vector);
 	Vector v = LUA->GetVector(2);
 	pMat->conductorInput = pMat->conductor = glm::clamp(glm::vec3(v.x, v.y, v.z), 0.f, 1.f);
 	return 0;
@@ -771,9 +806,18 @@ LUA_FUNCTION(Material_ConductorColour)
 LUA_FUNCTION(Material_EdgeTint)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
-	LUA->CheckType(2, Type::Vector);
-
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
+	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+		Vector v;
+		v.x = pMat->edgetint.x;
+		v.y = pMat->edgetint.y;
+		v.z = pMat->edgetint.z;
+		LUA->PushVector(v);
+
+		return 1;
+	}
+
+	LUA->CheckType(2, Type::Vector);
 	Vector v = LUA->GetVector(2);
 	pMat->edgetint = glm::clamp(glm::vec3(v.x, v.y, v.z), 0.f, 1.f);
 	return 0;
@@ -782,9 +826,13 @@ LUA_FUNCTION(Material_EdgeTint)
 LUA_FUNCTION(Material_EdgeTintFalloff)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
-	LUA->CheckType(2, Type::Number);
-
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
+	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+		LUA->PushNumber(pMat->falloff);
+		return 1;
+	}
+
+	LUA->CheckType(2, Type::Number);
 	pMat->falloff = glm::clamp(LUA->GetNumber(2), 0.001, 1.);
 	return 0;
 }
@@ -792,9 +840,13 @@ LUA_FUNCTION(Material_EdgeTintFalloff)
 LUA_FUNCTION(Material_Metalness)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
-	LUA->CheckType(2, Type::Number);
-
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
+	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+		LUA->PushNumber(pMat->metallic);
+		return 1;
+	}
+
+	LUA->CheckType(2, Type::Number);
 	pMat->metallic = glm::clamp(LUA->GetNumber(2), 0., 1.);
 	pMat->metallicOverridden = true;
 	return 0;
@@ -802,9 +854,13 @@ LUA_FUNCTION(Material_Metalness)
 LUA_FUNCTION(Material_Roughness)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
-	LUA->CheckType(2, Type::Number);
-
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
+	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+		LUA->PushNumber(pMat->roughness);
+		return 1;
+	}
+
+	LUA->CheckType(2, Type::Number);
 	pMat->linearRoughness = glm::clamp(LUA->GetNumber(2), 0., 1.);
 	pMat->roughness = pMat->linearRoughness * pMat->linearRoughness;
 	pMat->roughnessOverridden = true;
@@ -814,12 +870,16 @@ LUA_FUNCTION(Material_Roughness)
 LUA_FUNCTION(Material_Anisotropy)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
-	LUA->CheckType(2, Type::Number);
-
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
+	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+		LUA->PushNumber(pMat->anisotropy);
+		return 1;
+	}
+
 	// While anisotropy can be mapped -1 to 1
 	// with rotation it makes more sense to have it 0-1 (easily stored in a texture) and use rotation to change the direction
 	// This is also how blender's principled BSDF node does it
+	LUA->CheckType(2, Type::Number);
 	pMat->anisotropy = glm::clamp(LUA->GetNumber(2), 0., 1. - kMinGGXAlpha);
 	pMat->anisotropyOverriden = true;
 	return 0;
@@ -827,9 +887,13 @@ LUA_FUNCTION(Material_Anisotropy)
 LUA_FUNCTION(Material_AnisotropicRotation)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
-	LUA->CheckType(2, Type::Number);
-
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
+	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+		LUA->PushNumber(pMat->anisotropicRotation);
+		return 1;
+	}
+
+	LUA->CheckType(2, Type::Number);
 	pMat->anisotropicRotation = glm::clamp(LUA->GetNumber(2), 0., 1.) * 2. * glm::pi<double>();
 	pMat->anisotropicRotationOverriden = true;
 	return 0;
@@ -838,9 +902,13 @@ LUA_FUNCTION(Material_AnisotropicRotation)
 LUA_FUNCTION(Material_IoR)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
-	LUA->CheckType(2, Type::Number);
-
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
+	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+		LUA->PushNumber(pMat->ior);
+		return 1;
+	}
+
+	LUA->CheckType(2, Type::Number);
 	pMat->ior = LUA->GetNumber(2);
 	return 0;
 }
@@ -848,18 +916,26 @@ LUA_FUNCTION(Material_IoR)
 LUA_FUNCTION(Material_DiffuseTransmission)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
-	LUA->CheckType(2, Type::Number);
-
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
+	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+		LUA->PushNumber(pMat->diffuseTransmission);
+		return 1;
+	}
+
+	LUA->CheckType(2, Type::Number);
 	pMat->diffuseTransmission = glm::clamp(LUA->GetNumber(2), 0., 1.);
 	return 0;
 }
 LUA_FUNCTION(Material_SpecularTransmission)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
-	LUA->CheckType(2, Type::Number);
-
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
+	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+		LUA->PushNumber(pMat->specularTransmission);
+		return 1;
+	}
+
+	LUA->CheckType(2, Type::Number);
 	pMat->specularTransmission = glm::clamp(LUA->GetNumber(2), 0., 1.);
 	return 0;
 }
@@ -867,9 +943,13 @@ LUA_FUNCTION(Material_SpecularTransmission)
 LUA_FUNCTION(Material_Thin)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
-	LUA->CheckType(2, Type::Bool);
-
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
+	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+		LUA->PushBool(pMat->thin);
+		return 1;
+	}
+
+	LUA->CheckType(2, Type::Bool);
 	pMat->thin = LUA->GetBool(2);
 	return 0;
 }
@@ -878,6 +958,11 @@ LUA_FUNCTION(Material_ActiveLobes)
 {
 	LUA->CheckType(1, BSDFMaterial::id);
 	BSDFMaterial* pMat = LUA->GetUserType<BSDFMaterial>(1, BSDFMaterial::id);
+	if (LUA->IsType(2, Type::Nil) || LUA->IsType(2, Type::None)) {
+		LUA->PushNumber(static_cast<int>(pMat->activeLobes));
+		return 1;
+	}
+
 	LobeType lobes = static_cast<LobeType>(LUA->CheckNumber(2));
 
 	pMat->activeLobes = lobes;


### PR DESCRIPTION
Fixes #59.

**PR Type (tick all that are applicable)**
- [ ] Bug Fix
- [ ] New Feature (doesn't break Module <-> Lua compatibility)
- [x] New Feature (breaks Module <-> Lua compatibility)
- [ ] Documentation Update Required

**Tested Targets (only applicable for changes to the binary module, delete otherwise)**
- [x] windows-x64-release
- [ ] windows-x86-release

**Checklist**
- [x] I have read and understand the contributing guidelines
- [x] I have tested all aspects of this PR (not required)

**Description**
If the given argument for the BSDFMaterial setter is nil/no value, then it will instead act as a getter and return the currently set value.

Here's the only odd example with this PR.
![linear roughness](https://i.imgur.com/kCtCmpT.png)
Instead of returning the linear roughness that was given to the setter, the getter will instead return the raw roughness. This behavior sounds correct to me, but any comments on this? It may be confusing to users who aren't aware.

