### PR TITLE
Add TraceResult:Material

### DIFF
--- a/source/VisTrace.cpp
+++ b/source/VisTrace.cpp
@@ -461,6 +461,15 @@ LUA_FUNCTION(TraceResult_Incident)
 	return 1;
 }
 
+LUA_FUNCTION(TraceResult_Material)
+{
+	LUA->CheckType(1, TraceResult::id);
+	TraceResult* pResult = LUA->GetUserType<TraceResult>(1, TraceResult::id);
+
+	LUA->PushString(pResult->materialPath->c_str());
+	return 1;
+}
+
 LUA_FUNCTION(TraceResult_Distance)
 {
 	LUA->CheckType(1, TraceResult::id);
@@ -1589,6 +1598,7 @@ GMOD_MODULE_OPEN()
 		PUSH_C_FUNC(TraceResult, Roughness);
 
 		PUSH_C_FUNC(TraceResult, MaterialFlags);
+		PUSH_C_FUNC(TraceResult, Material);
 		PUSH_C_FUNC(TraceResult, SurfaceFlags);
 
 		PUSH_C_FUNC(TraceResult, HitSky);

--- a/source/objects/AccelStruct.cpp
+++ b/source/objects/AccelStruct.cpp
@@ -162,7 +162,7 @@ World::World(GarrysMod::Lua::ILuaBase* LUA, const std::string& mapName)
 			LUA->ThrowError(e.what());
 		}
 
-		const std::string strPath = tex.path;
+		std::string strPath = tex.path;
 		if (materialIds.find(strPath) == materialIds.end()) {
 			LUA->GetField(-1, "Material");
 			LUA->PushString(tex.path);
@@ -178,6 +178,7 @@ World::World(GarrysMod::Lua::ILuaBase* LUA, const std::string& mapName)
 
 			IMaterial* sourceMaterial = LUA->GetUserType<IMaterial>(-1, Type::Material);
 			Material mat{};
+			mat.path = strPath;
 			mat.maskedBlending = false;
 			
 			const char* shaderName = sourceMaterial->GetShaderName();
@@ -521,7 +522,7 @@ World::World(GarrysMod::Lua::ILuaBase* LUA, const std::string& mapName)
 			// Get material
 			LUA->GetField(-1, "material"); // _G util meshes mesh material
 			if (!LUA->IsType(-1, Type::String)) LUA->ThrowError("Submesh has no material");
-			std::string materialPath = LUA->GetString();
+			const std::string materialPath = LUA->GetString();
 			LUA->Pop(2); // _G util meshes
 
 			if (materialIds.find(materialPath) == materialIds.end()) {
@@ -532,6 +533,7 @@ World::World(GarrysMod::Lua::ILuaBase* LUA, const std::string& mapName)
 
 				IMaterial* sourceMaterial = LUA->GetUserType<IMaterial>(-1, Type::Material);
 				Material mat{};
+				mat.path = materialPath;
 				mat.maskedBlending = false;
 
 				std::string baseTexture = GetMaterialString(sourceMaterial, "$basetexture");
@@ -1013,6 +1015,7 @@ void AccelStruct::PopulateAccel(ILuaBase* LUA, const World* pWorld)
 				IMaterial* sourceMaterial = LUA->GetUserType<IMaterial>(-1, Type::Material);
 
 				Material mat{};
+				mat.path = materialPath;
 				mat.maskedBlending = false;
 
 				std::string baseTexture = GetMaterialString(sourceMaterial, "$basetexture");

--- a/source/objects/AccelStruct.cpp
+++ b/source/objects/AccelStruct.cpp
@@ -162,7 +162,7 @@ World::World(GarrysMod::Lua::ILuaBase* LUA, const std::string& mapName)
 			LUA->ThrowError(e.what());
 		}
 
-		std::string strPath = tex.path;
+		const std::string strPath = tex.path;
 		if (materialIds.find(strPath) == materialIds.end()) {
 			LUA->GetField(-1, "Material");
 			LUA->PushString(tex.path);
@@ -522,7 +522,7 @@ World::World(GarrysMod::Lua::ILuaBase* LUA, const std::string& mapName)
 			// Get material
 			LUA->GetField(-1, "material"); // _G util meshes mesh material
 			if (!LUA->IsType(-1, Type::String)) LUA->ThrowError("Submesh has no material");
-			const std::string materialPath = LUA->GetString();
+			std::string materialPath = LUA->GetString();
 			LUA->Pop(2); // _G util meshes
 
 			if (materialIds.find(materialPath) == materialIds.end()) {

--- a/source/objects/AccelStruct.h
+++ b/source/objects/AccelStruct.h
@@ -88,6 +88,8 @@ enum class DetailBlendMode : uint8_t
 
 struct Material
 {
+	std::string path = "";
+
 	glm::vec4 colour = glm::vec4(1.f);
 	const VisTrace::IVTFTexture* baseTexture = nullptr;
 	glm::mat2x4 baseTexMat = glm::identity<glm::mat2x4>();

--- a/source/objects/TraceResult.cpp
+++ b/source/objects/TraceResult.cpp
@@ -59,7 +59,8 @@ TraceResult::TraceResult(
 	detailScale(mat.detailScale), detailBlendFactor(mat.detailBlendFactor),
 	detailBlendMode(mat.detailBlendMode), detailTint(mat.detailTint),
 	detailAlphaMaskBaseTexture(mat.detailAlphaMaskBaseTexture),
-	texScale(mat.texScale)
+	texScale(mat.texScale),
+	materialPath(&mat.path)
 {
 	if (!triData.ignoreNormalMap) {
 		normalMap = mat.normalMap;

--- a/source/objects/TraceResult.h
+++ b/source/objects/TraceResult.h
@@ -90,6 +90,8 @@ public:
 	CBaseEntity* rawEnt;
 	uint32_t submatIdx;
 
+	const std::string* materialPath = nullptr;
+
 	MaterialFlags materialFlags;
 	BSPEnums::SURF surfaceFlags;
 	bool hitSky = false;


### PR DESCRIPTION
Fixes #77

**PR Type (tick all that are applicable)**
- [ ] Bug Fix
- [ ] New Feature (doesn't break Module <-> Lua compatibility)
- [x] New Feature (breaks Module <-> Lua compatibility)
- [ ] Documentation Update Required

**Tested Targets (only applicable for changes to the binary module, delete otherwise)**
- [x] windows-x64-release
- [ ] windows-x86-release

**Checklist**
- [x] I have read and understand the contributing guidelines
- [x] I have tested all aspects of this PR (not required)

**Description**
`TraceResult:Material()` returns the material path (local to `materials` of course) of the trace result.
I don't really see a need for multiple texture getters because you could literally just do
`Material(TraceResult:Material()):GetString("$basetexture")` and have more options in doing so.

Please explain further
