### PR TITLE
Add RenderTarget:Clone

### DIFF
--- a/include/vistrace/IRenderTarget.h
+++ b/include/vistrace/IRenderTarget.h
@@ -44,6 +44,7 @@ namespace VisTrace
 		virtual void SetPixel(uint16_t x, uint16_t y, const Pixel& pixel, uint8_t mip = 0) = 0;
 
 		virtual void GenerateMIPs() = 0;
+		virtual IRenderTarget* Clone() = 0;
 
 		virtual bool Save(const char* filename, uint8_t mip = 0) const = 0;
 		virtual bool Load(const char* filename, bool createMips = false) = 0;

--- a/source/VisTrace.cpp
+++ b/source/VisTrace.cpp
@@ -403,6 +403,16 @@ LUA_FUNCTION(RT_GenerateMIPs)
 	return 0;
 }
 
+LUA_FUNCTION(RT_Clone)
+{
+	LUA->CheckType(1, RenderTarget::id);
+	IRenderTarget* pRt = *LUA->GetUserType<IRenderTarget*>(1, RenderTarget::id);
+	if (!pRt->IsValid()) LUA->ThrowError("Invalid render target");
+
+	LUA->PushUserType_Value(pRt->Clone(), RenderTarget::id);
+	return 1;
+}
+
 LUA_FUNCTION(RT_Save)
 {
 	LUA->CheckType(1, RenderTarget::id);
@@ -1648,6 +1658,7 @@ GMOD_MODULE_OPEN()
 		PUSH_C_FUNC(RT, SetPixel);
 
 		PUSH_C_FUNC(RT, GenerateMIPs);
+		PUSH_C_FUNC(RT, Clone);
 
 		PUSH_C_FUNC(RT, Save);
 		PUSH_C_FUNC(RT, Load);

--- a/source/objects/RenderTarget.cpp
+++ b/source/objects/RenderTarget.cpp
@@ -247,6 +247,17 @@ void RenderTarget::GenerateMIPs()
 	}
 }
 
+IRenderTarget* RenderTarget::Clone() {
+	RenderTarget* rt = new RenderTarget(GetWidth(), GetHeight(), GetFormat(), mMips);
+
+	// Copy all of the mip levels (including the raw image, 0)
+	for (uint8_t mip = 0; mip < mMips; mip++) {
+		memcpy(rt->GetRawData(mip), GetRawData(mip), GetWidth(mip) * GetHeight(mip) * mPixelSize);
+	}
+
+	return rt;
+}
+
 bool RenderTarget::Save(const char* filename, uint8_t mip) const
 {
 	if (!IsValid() || mip >= mMips) return false;

--- a/source/objects/RenderTarget.h
+++ b/source/objects/RenderTarget.h
@@ -56,6 +56,7 @@ public:
 	void SetPixel(uint16_t x, uint16_t y, const VisTrace::Pixel& pixel, uint8_t mip = 0);
 
 	void GenerateMIPs();
+	IRenderTarget* Clone();
 
 	bool Save(const char* filename, uint8_t mip = 0) const;
 	bool Load(const char* filename, bool createMips = false);


### PR DESCRIPTION
Fixes #82 

**PR Type (tick all that are applicable)**
- [ ] Bug Fix
- [ ] New Feature (doesn't break Module <-> Lua compatibility)
- [x] New Feature (breaks Module <-> Lua compatibility)
- [x] Documentation Update Required

**Tested Targets (only applicable for changes to the binary module, delete otherwise)**
- [x] windows-x64-release
- [ ] windows-x86-release

**Checklist**
- [x] I have read and understand the contributing guidelines
- [ ] I have tested all aspects of this PR (not required)

**Description**
Allows Lua and C++ to clone `RenderTarget`s. C++ has to `delete` them, but Lua clones are garbage collected.

I did not test all aspects. I didn't have enough time to test if MIPs worked correctly, but they should if you see how I made the Clone function and given that the base image (MIP 0) works fine.

I used some code that's internal to my codebase but otherwise readable.
This code passed.
```lua
local display = vgui.Create("RTDisplay")
local rt = vistrace.CreateRenderTarget(512, 512, VisTraceRTFormat.RGBFFF)
rt:Load("512x512_gm_construct_1spp_5bounces_20220924180109.png")
rt:GenerateMIPs()

display:SetSize(512, 512)
display:SetVRT(rt)
display:Update()

timer.Simple(3, function()
	local newRT = rt:Clone()
	display:SetVRT(newRT)
	display:Update()
	print("Cloned!")

	timer.Simple(3, function()
		newRT:Load("512x512_gm_construct_1spp_5bounces_20220923192755.png")
		display:Update()
		timer.Simple(3, function()
			display:Remove()
		end)
	end)
end)
```
