### PR TITLE
Fix mipmapping regression

### DIFF
--- a/include/vistrace/Structs.h
+++ b/include/vistrace/Structs.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 namespace VisTrace
 {
 	struct Pixel

--- a/source/objects/AccelStruct.cpp
+++ b/source/objects/AccelStruct.cpp
@@ -403,6 +403,7 @@ World::World(GarrysMod::Lua::ILuaBase* LUA, const std::string& mapName)
 			Vector3{ vertices[vi1].x, vertices[vi1].y, vertices[vi1].z },
 			Vector3{ vertices[vi2].x, vertices[vi2].y, vertices[vi2].z },
 			world.materials[submatIds[strPath]],
+			uvs + vi0,
 
 			// Backface cull on the world to prevent z fighting on 2 sided water surfaces
 			// (given you shouldnt be refracting through any other brushes this should be fine)
@@ -411,7 +412,6 @@ World::World(GarrysMod::Lua::ILuaBase* LUA, const std::string& mapName)
 
 		memcpy(tri.normals, normals + vi0, sizeof(glm::vec3) * 3);
 		memcpy(tri.tangents, tangents + vi0, sizeof(glm::vec3) * 3);
-		memcpy(tri.uvs, uvs + vi0, sizeof(glm::vec2) * 3);
 		memcpy(tri.alphas, alphas + vi0, sizeof(float) * 3);
 
 		triangles.push_back(tri);

--- a/source/objects/Model.cpp
+++ b/source/objects/Model.cpp
@@ -101,8 +101,6 @@ Mesh::Mesh(
 								tri.tangents[j] = glm::normalize(glm::vec3(tri.e1[0], tri.e1[1], tri.e1[2]));
 							}
 
-							tri.uvs[j] = uvs[j];
-
 							if (vtxVerts[j]->numBones > 0) {
 								tri.numBones[j] = vtxVerts[j]->numBones;
 

--- a/source/objects/Model.cpp
+++ b/source/objects/Model.cpp
@@ -73,11 +73,18 @@ Mesh::Mesh(
 							tangents[j] = GetModel()->GetTangent(mesh->GetTangentIndex(vtxVerts[j]));
 						}
 
+						const glm::vec2 uvs[3] = {
+							glm::vec2(verts[0]->texCoord.x, verts[0]->texCoord.y),
+							glm::vec2(verts[1]->texCoord.x, verts[1]->texCoord.y),
+							glm::vec2(verts[2]->texCoord.x, verts[2]->texCoord.y)
+						};
+
 						Triangle tri(
 							Vector3(verts[0]->pos.x, verts[0]->pos.y, verts[0]->pos.z),
 							Vector3(verts[1]->pos.x, verts[1]->pos.y, verts[1]->pos.z),
 							Vector3(verts[2]->pos.x, verts[2]->pos.y, verts[2]->pos.z),
 							mesh->material,
+							uvs,
 							false
 						);
 
@@ -94,7 +101,7 @@ Mesh::Mesh(
 								tri.tangents[j] = glm::normalize(glm::vec3(tri.e1[0], tri.e1[1], tri.e1[2]));
 							}
 
-							tri.uvs[j] = glm::vec2(verts[j]->texCoord.x, verts[j]->texCoord.y);
+							tri.uvs[j] = uvs[j];
 
 							if (vtxVerts[j]->numBones > 0) {
 								tri.numBones[j] = vtxVerts[j]->numBones;

--- a/source/objects/Primitives.h
+++ b/source/objects/Primitives.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Utils.h>
+
 #include "Material.h"
 
 class AccelStruct;
@@ -75,9 +77,14 @@ struct TriangleBackfaceCull
 		const bvh::Vector3<Scalar> p1,
 		const bvh::Vector3<Scalar> p2,
 		const int16_t material,
+		const glm::vec2 uvs[3],
 		const bool oneSided = false
-	) : p0(p0), e1(p0 - p1), e2(p2 - p0), material(material), oneSided(oneSided)
+	) : p0(p0), e1(p0 - p1), e2(p2 - p0), material(material), uvs(), oneSided(oneSided)
 	{
+		this->uvs[0] = uvs[0];
+		this->uvs[1] = uvs[1];
+		this->uvs[2] = uvs[2];
+
 		ComputeNormalAndLoD();
 	}
 

--- a/source/objects/Primitives.h
+++ b/source/objects/Primitives.h
@@ -79,7 +79,7 @@ struct TriangleBackfaceCull
 		const int16_t material,
 		const glm::vec2 uvs[3],
 		const bool oneSided = false
-	) : p0(p0), e1(p0 - p1), e2(p2 - p0), material(material), uvs(), oneSided(oneSided)
+	) : p0(p0), e1(p0 - p1), e2(p2 - p0), material(material), oneSided(oneSided)
 	{
 		this->uvs[0] = uvs[0];
 		this->uvs[1] = uvs[1];


### PR DESCRIPTION
Fixes #96 

**PR Type (tick all that are applicable)**
- [x] Bug Fix
- [ ] New Feature (doesn't break Module <-> Lua compatibility)
- [ ] New Feature (breaks Module <-> Lua compatibility)
- [ ] Documentation Update Required

**Tested Targets (only applicable for changes to the binary module, delete otherwise)**
- [x] windows-x64-release
- [ ] windows-x86-release

**Checklist**
- [x] I have read and understand the contributing guidelines
- [x] I have tested all aspects of this PR (not required)

**Description**
Properly passes the UVs of any world/model triangle into the `TriangleBackfaceCull` class so that the data is intact once it calls `ComputeNormalAndLoD()`